### PR TITLE
[EXPERIMENTAL] Hotfix for new Find function

### DIFF
--- a/lua/autorun/sb_autostart.lua
+++ b/lua/autorun/sb_autostart.lua
@@ -23,6 +23,29 @@ end
 
 local sb = sb
 
+
+---- Experimental ----
+function sb.wrappers:Find(type,name,path,sort)
+
+	if name ~= nil and path ~= nil then
+		if sort then
+			files,dirs = file.Find(name,path,sort)
+		else
+			files,dirs = file.Find(name,path)
+		end
+
+		if type == "file" then
+			return files
+		elseif type == "dir" then
+			return dirs
+		end
+
+	else
+		return nil
+	end	
+end
+----------------------
+
 if not sb then
 	error("SB CORE: failed loading SB core")
 end
@@ -37,15 +60,16 @@ if sb.config and sb.config.testMode then
 	luaunit.run() -- will execute all tests
 end
 
-if sb.config then -- Below finds extensions, and their config files.
+if sb.config and sb.wrappers then -- Below finds extensions, and their config files.
 
 	local basePath = "sb/extensions/"
-	local dirList = file.FindDir(basePath.."*", "LUA")
-
+	local dirList = sb.wrappers:Find("dir",basePath.."*", "LUA")
 
 	for i, j in ipairs(dirList) do
 
-		local configs = file.Find(basePath..j.."/config.lua", "LUA")
+		local configs = sb.wrappers:Find("file",basePath..j.."/config.lua", "LUA")
+
+		MsgN(type(configs))
 
 		if #configs > 0 then
 

--- a/lua/sb/core/class.lua
+++ b/lua/sb/core/class.lua
@@ -44,6 +44,6 @@ end
 
 function class.exists(name)
     name = tostring(name);
-    return classes[name] ~= nil or #file.Find("sb/classes/" .. name .. ".lua", "LUA") == 1 -- Changed LUA_PATH to new format, blame Garry
+    return classes[name] ~= nil or #sb.wrappers:Find("file","sb/classes/" .. name .. ".lua", "LUA") == 1 --FUCK YOU GARRY
 end
 

--- a/lua/sb/core/init.lua
+++ b/lua/sb/core/init.lua
@@ -28,6 +28,11 @@ sb.lang = {}
 sb.log = {}
 sb.util = {}
 sb.test = {}
+---- experimental ----
+
+sb.wrappers = {}
+
+----------------------
 
 include("sb/core/config.lua");
 include("sb/core/class.lua");


### PR DESCRIPTION
See commit message. Essentially Garry again changed things related to finding files and directories. He merged them both into file.Find. It now requires multi-var assignment to work correctly, and even then occasionally spits out tables with 0 length. I implemented a "wrapper" table, part of the sb global, which we can add methods to which can fix things or make them more suitable to our needs. Such as the file.FindDir, i've implemented that by making sb.wrapper:Find accept a type as the first parameter.

I'm sick and tired of him changing things every 2 minutes, and then having to change the way the code works because he's completely changed a core function, this should avoid such dependencies, and as the code base grows it should speed up fixes due to these changes by making them appear only once.

If there is a better place to put these, please advise me, otherwise it stays like this until Garry sorts his #@!$ out.
