### PR TITLE
Fix water generator on maps without environment

### DIFF
--- a/lua/entities/generator_liquid_water/init.lua
+++ b/lua/entities/generator_liquid_water/init.lua
@@ -173,6 +173,7 @@ function ENT:Pump_Water()
         islava = self.environment:GetTemperature(self) --Check to see if it's in lava
     else
         islava = 66 --any number below 308 would do, i picked nonzero to assert evaluation as a number
+    end
     if CAF then
         waterlevel = self:WaterLevel2()
     else

--- a/lua/entities/generator_liquid_water/init.lua
+++ b/lua/entities/generator_liquid_water/init.lua
@@ -169,7 +169,10 @@ function ENT:Pump_Water()
     local energy = self:GetResourceAmount("energy")
     local einc = Energy_Increment + (self.overdrive * Energy_Increment * 3)
     local waterlevel = 0
-    islava = self.environment:GetTemperature(self) --Check to see if it's in lava
+    if self.environment then
+        islava = self.environment:GetTemperature(self) --Check to see if it's in lava
+    else
+        islava = 66 --any number below 308 would do, i picked nonzero to assert evaluation as a number
     if CAF then
         waterlevel = self:WaterLevel2()
     else


### PR DESCRIPTION
You forgot to check if `self.environment` existed before calling it. Would work fine for actual Spacebuild maps, but breaks when screwballs like me try to use LS3 on regular sandbox maps.
