### PR TITLE
More escape fixes

### DIFF
--- a/lua/weapons/gmod_tool/stools/rd3_dev_link.lua
+++ b/lua/weapons/gmod_tool/stools/rd3_dev_link.lua
@@ -197,7 +197,7 @@ function TOOL:RightClick( trace )
 					if Ent1:GetNode() and Ent1:GetNode() == Ent2 then
 						Ent1:SetNode(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				else
 					if Ent1:GetNode() and Ent1:GetNode1() == Ent2 then
@@ -205,7 +205,7 @@ function TOOL:RightClick( trace )
 					elseif Ent1:GetNode2() and Ent1:GetNode2() == Ent2 then
 						Ent1:SetNode2(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				end
 			elseif Ent2.IsValve and Ent1.IsNode then
@@ -213,7 +213,7 @@ function TOOL:RightClick( trace )
 					if Ent2:GetNode() and Ent2:GetNode() == Ent1 then
 						Ent2:SetNode(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				else
 					if Ent2:GetNode() and Ent2:GetNode1() == Ent1 then
@@ -221,7 +221,7 @@ function TOOL:RightClick( trace )
 					elseif Ent2:GetNode2() and Ent2:GetNode2() == Ent1 then
 						Ent2:SetNode2(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				end
 			elseif Ent1.IsPump and Ent2.IsNode then
@@ -236,13 +236,13 @@ function TOOL:RightClick( trace )
 				if Ent1:GetRDEntity() and Ent1:GetRDEntity() == Ent2 then
 					Ent1:SetRDEntity(nil)
 				else
-					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren't connected!', NOTIFY_GENERIC, 7);" )
+					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 				end
 			elseif Ent2.IsValve and Ent2.IsEntityValve and table.Count(CAF.GetAddon("Resource Distribution").GetEntityTable(Ent1)) > 0 then
 				if Ent2:GetRDEntity() and Ent2:GetRDEntity() == Ent1 then
 					Ent2:SetRDEntity(nil)
 				else
-					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren't connected!', NOTIFY_GENERIC, 7);" )
+					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 				end
 			elseif Ent1.IsNode and table.Count(CAF.GetAddon("Resource Distribution").GetEntityTable(Ent2)) > 0 and CAF.GetAddon("Resource Distribution").GetEntityTable(Ent2).network == Ent1.netid then
 				CAF.GetAddon("Resource Distribution").Unlink(Ent2)

--- a/lua/weapons/gmod_tool/stools/rd3_dev_link_en_valve.lua
+++ b/lua/weapons/gmod_tool/stools/rd3_dev_link_en_valve.lua
@@ -159,7 +159,7 @@ function TOOL:RightClick( trace )
 					if Ent1:GetNode() and Ent1:GetNode() == Ent2 then
 						Ent1:SetNode(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				else
 					if Ent1:GetNode() and Ent1:GetNode1() == Ent2 then
@@ -167,7 +167,7 @@ function TOOL:RightClick( trace )
 					elseif Ent1:GetNode2() and Ent1:GetNode2() == Ent2 then
 						Ent1:SetNode2(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				end
 			elseif Ent2.IsValve and Ent1.IsNode then
@@ -175,7 +175,7 @@ function TOOL:RightClick( trace )
 					if Ent2:GetNode() and Ent2:GetNode() == Ent1 then
 						Ent2:SetNode(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				else
 					if Ent2:GetNode() and Ent2:GetNode1() == Ent1 then
@@ -183,7 +183,7 @@ function TOOL:RightClick( trace )
 					elseif Ent2:GetNode2() and Ent2:GetNode2() == Ent1 then
 						Ent2:SetNode2(nil)
 					else
-						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren't connected!', NOTIFY_GENERIC, 7);" )
+						self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Resource Node Valve and Resource Node weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 					end
 				end
 			elseif Ent1.IsPump and Ent2.IsNode then
@@ -198,13 +198,13 @@ function TOOL:RightClick( trace )
 				if Ent1:GetRDEntity() and Ent1:GetRDEntity() == Ent2 then
 					Ent1:SetRDEntity(nil)
 				else
-					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren't connected!', NOTIFY_GENERIC, 7);" )
+					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 				end
 			elseif Ent2.IsValve and Ent2.IsEntityValve and table.Count(CAF.GetAddon("Resource Distribution").GetEntityTable(Ent1)) > 0 then
 				if Ent2:GetRDEntity() and Ent2:GetRDEntity() == Ent1 then
 					Ent2:SetRDEntity(nil)
 				else
-					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren't connected!', NOTIFY_GENERIC, 7);" )
+					self:GetOwner():SendLua( "GAMEMODE:AddNotify('This Entity Valve and Entity weren\\'t connected!', NOTIFY_GENERIC, 7);" )
 				end
 			elseif Ent1.IsNode and table.Count(CAF.GetAddon("Resource Distribution").GetEntityTable(Ent2)) > 0 and CAF.GetAddon("Resource Distribution").GetEntityTable(Ent2).network == Ent1.netid then
 				CAF.GetAddon("Resource Distribution").Unlink(Ent2)


### PR DESCRIPTION
Just fixing more of those
```
[ERROR] LuaCmd:1: ')' expected near 't'
  1. unknown - LuaCmd:0
```
errors caused by un-escaped strings.