### PR TITLE
fix annoying lua error

### DIFF
--- a/lua/autorun/server/sv_caf_autostart.lua
+++ b/lua/autorun/server/sv_caf_autostart.lua
@@ -313,6 +313,7 @@ function CAF2.Start()
 	end
 	CAF2.StartingUp = false
 	net.Start("CAF_Start_false")
+	net.Broadcast()
 end
 hook.Add( "InitPostEntity", "CAF_Start", CAF2.Start)
 


### PR DESCRIPTION
Added a missing net.Broadcast() to the CAF2.Start() function on line 316, prevents annoying Lua error when another addon makes a net message.