### PR TITLE
Fixed weapon pickup and mapstart errors

### DIFF
--- a/lua/autorun/server/sv_caf_autostart.lua
+++ b/lua/autorun/server/sv_caf_autostart.lua
@@ -121,7 +121,7 @@ local function LoadAddonStatus( addon, defaultstatus )
 end
 
 local function OnEntitySpawn(ent , enttype , ply)
-	if ent:IsValid() ~= true then
+	if IsValid(ent) ~= true then
 		return
 	end
 	ent.caf = ent.caf or {}

--- a/lua/entities/other_screen/init.lua
+++ b/lua/entities/other_screen/init.lua
@@ -114,11 +114,15 @@ function ENT:Initialize()
 end
 
 function ENT:TurnOn()
-	if self.Active == 0 then
-		self:EmitSound( "Buttons.snd17" )
-		self.Active = 1
-		self:SetOOO(1)
-		if not (WireAddon == nil) then Wire_TriggerOutput(self, "On", 1) end
+	if(self:GetResourceAmount("energy") > math.Round(Energy_Increment * self:GetMultiplier())) then
+		if self.Active == 0 then
+			self:EmitSound( "Buttons.snd17" )
+			self.Active = 1
+			self:SetOOO(1)
+			if not (WireAddon == nil) then Wire_TriggerOutput(self, "On", 1) end
+		end
+	else
+		self:EmitSound("common/warning.wav")
 	end
 end
 


### PR DESCRIPTION
- Fixed error if you picked up a weapon right after spawning it (if you spawned it at your feet)
- Fixed error when map starts